### PR TITLE
Add loadBundle method in BundleCore & Framework.

### DIFF
--- a/bundle/src/ctrip/android/bundle/framework/BundleCore.java
+++ b/bundle/src/ctrip/android/bundle/framework/BundleCore.java
@@ -121,6 +121,9 @@ public class BundleCore {
         return Framework.installNewBundle(location, inputStream);
     }
 
+    public Bundle loadBundle(String location) throws Exception {
+        return Framework.loadBundle(location);
+    }
 
     public void updateBundle(String location, InputStream inputStream) throws BundleException {
         Bundle bundle = Framework.getBundle(location);

--- a/bundle/src/ctrip/android/bundle/framework/Framework.java
+++ b/bundle/src/ctrip/android/bundle/framework/Framework.java
@@ -227,5 +227,14 @@ public final class Framework {
         return bundleImpl;
     }
 
+    static BundleImpl loadBundle(String location) throws Exception {
+        BundleImpl bundleImpl = (BundleImpl) getBundle(location);
+        if (bundleImpl != null) {
+            return bundleImpl;
+        }
+        bundleImpl = new BundleImpl(new File(location));
+        bundles.put(location, bundleImpl);
+        return bundleImpl;
+    }
 
 }

--- a/sample/src/ctrip/android/sample/BundleBaseApplication.java
+++ b/sample/src/ctrip/android/sample/BundleBaseApplication.java
@@ -45,6 +45,17 @@ public class BundleBaseApplication extends Application {
             BundleCore.getInstance().startup(properties);
             if (isDexInstalled) {
                 HotPatchManager.getInstance().run();
+                File libsPath = new File(getFilesDir() + "/storage/");
+                try {
+                    for (File bundleDir : libsPath.listFiles()){
+                        if (!bundleDir.isDirectory()){  //Skip meta file.
+                            continue;
+                        }
+                        BundleCore.getInstance().loadBundle(bundleDir.getAbsolutePath());
+                    }
+                } catch (Exception e){
+                    e.printStackTrace();
+                }
                 BundleCore.getInstance().run();
             } else {
                 new Thread(new Runnable() {


### PR DESCRIPTION
Add loadBundle method in BundleCore & Framework.
Modified BaseApplication.

If so files are already extracted, load them to framework.
Currently, when sample project's activity is destroyed and launched again, the bundle framework will not load extracted bundle and will cause a ClassNotFoundException when we invoke classes in plugin APK.

Modified code will fix this issue.

Thanks.
